### PR TITLE
v5.8.2: Admin QA / Dev Safety Pack

### DIFF
--- a/src/SwagRunnerNightCityGame.jsx
+++ b/src/SwagRunnerNightCityGame.jsx
@@ -548,6 +548,7 @@ export default function SwagRunnerNightCityGame(){
   if(!requireDevReason("set role"))return;
   if(!["player","dev"].includes(devTargetRole))return setToast("Invalid role,account_status,suspended_until");
   if(!confirm(`Set ${devTarget.username} role to ${devTargetRole}?`))return;
+  if(!requireDevSafety(`set-role-${devTargetRole}`,devTarget.username))return;
   setDevBusy(true);
   try{
    await supabase.from("profiles").update({role:devTargetRole,updated_at:new Date().toISOString()}).eq("id",devTarget.id);
@@ -561,6 +562,7 @@ export default function SwagRunnerNightCityGame(){
   if(!supabase||!user||!isDev||!devTarget)return setToast("Dev only");
   if(!requireDevReason("remove leaderboard score"))return;
   if(!confirm(`Remove ${devTarget.username} from leaderboard?`))return;
+  if(!requireDevSafety("remove-leaderboard",devTarget.username))return;
   setDevBusy(true);
   try{
    await supabase.from("leaderboard").delete().eq("user_id",devTarget.id);
@@ -575,6 +577,7 @@ export default function SwagRunnerNightCityGame(){
   if(!supabase||!user||!isDev||!devTarget)return setToast("Dev only");
   if(!requireDevReason("reset avatar/bio"))return;
   if(!confirm(`Reset avatar and bio for ${devTarget.username}?`))return;
+  if(!requireDevSafety("reset-profile-public",devTarget.username))return;
   setDevBusy(true);
   try{
    await supabase.from("profiles").update({bio:"",avatar_url:null,updated_at:new Date().toISOString()}).eq("id",devTarget.id);
@@ -589,6 +592,17 @@ export default function SwagRunnerNightCityGame(){
  function requireDevReason(action="action"){
   if(!devReason.trim()){
    setToast(`DEV: ต้องกรอกเหตุผลก่อนทำ ${action}`);
+   return false;
+  }
+  return true;
+ }
+ function requireDevSafety(actionLabel,targetName=""){
+  const action=String(actionLabel||"critical action").trim();
+  const target=String(targetName||devTarget?.username||"target").trim();
+  const phrase=`CONFIRM ${action.toUpperCase()} ${target.toUpperCase()}`;
+  const input=prompt(`DEV SAFETY CHECK\nType this exactly to continue:\n${phrase}`,"")||"";
+  if(input.trim()!==phrase){
+   setToast("DEV safety check failed — action cancelled");
    return false;
   }
   return true;
@@ -610,6 +624,7 @@ export default function SwagRunnerNightCityGame(){
    until=new Date(Date.now()+days*24*60*60*1000).toISOString();
   }
   if(!confirm(`Set ${devTarget.username} status to ${status}?`))return;
+  if(!requireDevSafety(`set-status-${status}`,devTarget.username))return;
   setDevBusy(true);
   try{
    await supabase.from("profiles").update({account_status:status,suspended_until:until,updated_at:new Date().toISOString()}).eq("id",devTarget.id);
@@ -624,6 +639,7 @@ export default function SwagRunnerNightCityGame(){
   if(!supabase||!user||!isDev||!devTarget)return setToast("Dev only");
   if(!requireDevReason("reset score"))return;
   if(!confirm(`Reset score for ${devTarget.username}?`))return;
+  if(!requireDevSafety("reset-score",devTarget.username))return;
   setDevBusy(true);
   try{
    await Promise.all([
@@ -641,6 +657,7 @@ export default function SwagRunnerNightCityGame(){
   if(!supabase||!user||!isDev||!devTarget)return setToast("Dev only");
   if(!requireDevReason("reset wardrobe"))return;
   if(!confirm(`Reset wardrobe for ${devTarget.username}?`))return;
+  if(!requireDevSafety("reset-wardrobe",devTarget.username))return;
   setDevBusy(true);
   try{
    await Promise.all([


### PR DESCRIPTION
### Motivation
- Add an extra safety layer to in-game admin/dev tooling to prevent accidental destructive actions on player accounts.
- Require an explicit, typed confirmation phrase in addition to existing click-confirm dialogs for high-impact operations.
- Keep gameplay and obstacle logic unchanged and avoid touching project config files specified in the issue.

### Description
- Introduce a new `requireDevSafety(actionLabel, targetName)` function that prompts for an exact confirmation phrase (`CONFIRM <ACTION> <TARGET>`) before proceeding.
- Add `requireDevSafety` checks to critical dev functions: `devSetTargetRoleNow`, `devSetAccountStatus`, `devRemoveTargetScore`, `devResetTargetScoreFull`, `devResetTargetStyleShop`, and `devResetTargetProfilePublic`.
- Preserve the existing `requireDevReason` pre-check and the original `confirm(...)` dialogs so actions now require three-step approval: reason, confirm dialog, and exact-phrase gate.
- Confine changes to admin/dev tooling paths inside `src/SwagRunnerNightCityGame.jsx` and do not modify gameplay/obstacle code or the repository config files.

### Testing
- Ran a production build with `npm run build` (invokes `vite build`) and the build completed successfully.
- Verified the app compiles and bundles (build output produced `dist/` assets without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f586d6eb108323821fa6aeb8e259cd)